### PR TITLE
Fichier de configuration grappe cdsi-intro-hpc

### DIFF
--- a/cdsi-intro-hpc/common.tf
+++ b/cdsi-intro-hpc/common.tf
@@ -1,0 +1,1 @@
+../common/common.tf

--- a/cdsi-intro-hpc/config.yaml
+++ b/cdsi-intro-hpc/config.yaml
@@ -1,0 +1,1 @@
+jupyterhub::kernel::venv::packages: ['numpy']

--- a/cdsi-intro-hpc/main.tf
+++ b/cdsi-intro-hpc/main.tf
@@ -1,0 +1,17 @@
+locals {
+  custom = {
+    nnodes = {
+      cpupool = 4
+    }
+    home_size = 240
+    project_size = 240
+    scratch_size = 240
+
+    user_quotas = {
+      home = "3g"
+      project = "3g"
+      scratch = "3g"
+    }
+  }
+  name = "cdsi-intro-hpc"
+}


### PR DESCRIPTION
J'ai mis `cpupool = 4` puisque 2x plus d'étudiants (80 au lieu de 40).  La config du dernier cours était à `cpu=2`.